### PR TITLE
Fix: init script status function doesn't work

### DIFF
--- a/files/default/init-smartmontools
+++ b/files/default/init-smartmontools
@@ -1,0 +1,137 @@
+#!/bin/sh -e
+# 
+# smartmontools init.d startup script
+#
+# (C) 2003,04,07 Guido Günther <agx@sigxcpu.org>
+# 
+# loosely based on the init script that comes with smartmontools which is
+# copyrighted 2002 by Bruce Allen <smartmontools-support@lists.sourceforge.net>
+#
+### BEGIN INIT INFO
+# Provides:          smartmontools
+# Required-Start:    $syslog $remote_fs
+# Required-Stop:     $syslog $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      1
+# Short-Description: SMART monitoring daemon
+### END INIT INFO
+
+SMARTCTL=/usr/sbin/smartctl
+DAEMON=/usr/sbin/smartd
+PIDFILE=/var/run/smartd.pid
+[ -x $SMARTCTL ] || exit 0
+[ -x $DAEMON ] || exit 0
+. /lib/lsb/init-functions
+
+RET=0
+
+[ -r /etc/default/rcS ] && . /etc/default/rcS
+[ -r /etc/default/smartmontools ] && . /etc/default/smartmontools
+
+smartd_opts="--pidfile $PIDFILE $smartd_opts"
+
+enable_smart() {
+  log_action_begin_msg "Enabling S.M.A.R.T."
+  for device in $enable_smart; do
+      log_action_cont_msg "$device"
+      if ! $SMARTCTL --quietmode=errorsonly --smart=on $device; then
+          log_action_cont_msg "(failed)"
+          RET=2
+      fi
+  done
+  log_action_end_msg 0
+}
+
+check_start_smartd_option() {
+  if [ ! "$start_smartd" = "yes" ]; then
+    [ "$VERBOSE" = "yes" ] && log_warning_msg "Not starting S.M.A.R.T. daemon smartd, disabled via /etc/default/smartmontools"
+    return 1
+  else
+    return 0
+  fi
+}
+
+running_pid()
+{
+    # Check if a given process pid's cmdline matches a given name
+    pid=$1
+    name=$2
+    [ -z "$pid" ] && return 1 
+    [ ! -d /proc/$pid ] &&  return 1
+    cmd=`cat /proc/$pid/cmdline | tr "\000" "\n"|head -n 1 |cut -d : -f 1`
+    # Is this the expected child?
+    [ "$cmd" != "$name" ] &&  return 1
+    return 0
+}
+
+running()
+{
+# Check if the process is running looking at /proc
+# (works for all users)
+    # No pidfile, probably no daemon present
+    [ ! -f "$PIDFILE" ] && return 1
+    # Obtain the pid and check it against the binary name
+    pid=`cat $PIDFILE`
+    running_pid $pid $DAEMON || return 1
+    return 0
+}
+
+case "$1" in
+  start)
+        [ -n "$enable_smart" ] && enable_smart
+	if check_start_smartd_option; then
+
+	    log_daemon_msg "Starting S.M.A.R.T. daemon" "smartd"
+	    if running; then
+	        log_progress_msg "already running"
+	        log_end_msg 0
+	        exit 0
+	    fi
+	    rm -f $PIDFILE
+	    if start-stop-daemon --start --quiet --pidfile $PIDFILE \
+	                --exec $DAEMON -- $smartd_opts; then 
+	        log_end_msg 0
+	    else
+	        log_end_msg 1
+	        RET=1
+	    fi
+	fi
+	;;
+  stop)
+	log_daemon_msg "Stopping S.M.A.R.T. daemon" "smartd"
+	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+	log_end_msg 0
+	;;
+  reload|force-reload)
+	  log_daemon_msg "Reloading S.M.A.R.T. daemon" "smartd"
+	if start-stop-daemon --stop --quiet --signal 1 \
+	                --pidfile $PIDFILE; then
+	    log_end_msg 0
+	else
+	    log_end_msg 1
+	    RET=1
+	fi
+	  ;;
+  restart)
+	if check_start_smartd_option; then
+	    log_daemon_msg "Restarting S.M.A.R.T. daemon" "smartd"
+	    start-stop-daemon --stop --quiet --oknodo --retry 30 --pidfile $PIDFILE
+	    rm -f $PIDFILE
+	    if start-stop-daemon --start --quiet --pidfile $PIDFILE \
+	                --exec $DAEMON -- $smartd_opts; then 
+	        log_end_msg 0
+	    else
+	        log_end_msg 1
+	        RET=1
+	    fi
+	fi
+        ;;
+  status)
+	status_of_proc $DAEMON smartd && exit 0 || exit $?  
+	;;
+  *)
+	echo "Usage: /etc/init.d/smartmontools {start|stop|restart|reload|force-reload|status}"
+	exit 1
+esac
+
+exit $RET

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,6 +48,15 @@ node['smartmontools']['run_d'].each do |rund|
 
 end
 
+# Fix Ubuntu bug #491324: init script status function doesn't work
+cookbook_file "/etc/init.d/smartmontools" do
+  source "init-smartmontools"
+  owner "root"
+  group "root"
+  mode "0755"
+  only_if do (node[:platform] == 'ubuntu') && (node[:platform_version] == '10.04') end
+end
+
 service "smartmontools" do
   supports :status => true, :reload => true, :restart => true
   action [:enable,:start]


### PR DESCRIPTION
Hi Joshua,

in Lucid, the status action of the init script doesn't work (see Ubuntu bug #491324), so Chef executes the start action at every run.

I added a init script with the fix to the cookbook.

Best regards,
  Jochen
