### PR TITLE
Add CentOS support: Set servicename through value_for_platform for OS

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,3 +7,4 @@ version          "1.0.0"
 
 supports "debian", ">= 6.0"
 supports "ubuntu", ">= 10.04"
+supports "centos", ">= 5.7"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+service_name = value_for_platform([ "centos", "redhat", "fedora" ] => {"default" => "smartd"}, "default" => "smartmontools")
+
 package "smartmontools" do
   action :upgrade
 end
@@ -26,7 +28,7 @@ template "/etc/default/smartmontools" do
   owner "root"
   group "root"
   mode 0644
-  notifies :reload, "service[smartmontools]"
+  notifies :reload, "service[#{service_name}]"
 end
 
 template "/etc/smartd.conf" do
@@ -34,7 +36,7 @@ template "/etc/smartd.conf" do
   owner "root"
   group "root"
   mode 0644
-  notifies :reload, "service[smartmontools]"
+  notifies :reload, "service[#{service_name}]"
 end
 
 node['smartmontools']['run_d'].each do |rund|
@@ -57,7 +59,7 @@ cookbook_file "/etc/init.d/smartmontools" do
   only_if do (node[:platform] == 'ubuntu') && (node[:platform_version] == '10.04') end
 end
 
-service "smartmontools" do
+service "#{service_name}" do
   supports :status => true, :reload => true, :restart => true
   action [:enable,:start]
 end


### PR DESCRIPTION
CentOS doesn't know "smartmontools" as a service and calls it "smartd".

This pull request introduces a new variable for setting the servicename per OS through "value_for_platform", so CentOS knows the correct service name.

Tested on CentOS 5.7.
