### PR TITLE
ci: fix reusable workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
   lint-unit:
     uses: sous-chefs/.github/.github/workflows/lint-unit.yml@6.0.0
     permissions:
-      actions: write
       checks: write
       pull-requests: write
       statuses: write

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,3 +12,5 @@ name: conventional-commits
 jobs:
   conventional-commits:
     uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@6.0.0
+    permissions:
+      pull-requests: read

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -12,5 +12,7 @@ name: prevent-file-change
 jobs:
   prevent-file-change:
     uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@6.0.0
+    permissions:
+      pull-requests: write
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- grant `pull-requests: read` to the `conventional-commits` reusable workflow caller
- grant `pull-requests: write` to the `prevent-file-change` reusable workflow caller
- align `lint-unit` caller permissions with the nested `lint-unit.yml@6.0.0` workflow

## Source Check

- `sous-chefs/.github/.github/workflows/conventional-commits.yml@6.0.0` requests `pull-requests: read`
- `sous-chefs/.github/.github/workflows/prevent-file-change.yml@6.0.0` requests `pull-requests: write`
- `sous-chefs/.github/.github/workflows/lint-unit.yml@6.0.0` requests `checks: write`, `pull-requests: write`, and `statuses: write`

## Verification

- `actionlint`
